### PR TITLE
Added remaining reference links to footers

### DIFF
--- a/development.html
+++ b/development.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -7,6 +8,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="luyen/merged_styles.css">
 </head>
+
 <body>
     <!-- Navigation Bar -->
     <nav class="navbar navbar-expand-lg fixed-top bg-transparent">
@@ -17,142 +19,333 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav">
-                  
+
                     <li class="nav-item"><a class="nav-link text-white" href="test/index.html">HOME</a></li>
-                        <li class="nav-item"><a class="nav-link text-white" href="ABOUT_UPDATE_1.html">ABOUT</a></li>
-                        <li class="nav-item"><a class="nav-link text-white" href="development.html">DEVELOPMENT</a></li>
-                        <li class="nav-item"><a class="nav-link text-white" href="reception.html">RECEPTION</a></li>
-                        <li class="nav-item"><a class="nav-link text-white" href="legacy.html">LEGACY</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="ABOUT_UPDATE_1.html">ABOUT</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="development.html">DEVELOPMENT</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="reception.html">RECEPTION</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="legacy.html">LEGACY</a></li>
                 </ul>
             </div>
         </div>
     </nav>
     <!-- Main Content -->
     <main class="container">
-    <section>
-        <h1>Overview</h1>
-        <div class="image-container-dev">
-            <div>
-                <img src="luyen/Leslie_Benzies_@_Everywhere_Game.jpg" alt="Leslie Benzies">
-                <p>
-                    <a href="https://en.wikipedia.org/wiki/Rockstar_North" title="Leslie Benzies">Leslie Benzies</a>
+        <section>
+            <h1>Overview</h1>
+            <div class="image-container-dev">
+                <div>
+                    <img src="luyen/Leslie_Benzies_@_Everywhere_Game.jpg" alt="Leslie Benzies">
+                    <p>
+                        <a href="https://en.wikipedia.org/wiki/Rockstar_North" title="Leslie Benzies">Leslie Benzies</a>
+                    </p>
+                </div>
+
+                <div>
+                    <img src="luyen/Dan_Houser_at_Rockstar_Games.png" alt="Dan Houser">
+                    <p>
+                        <a href="https://en.wikipedia.org/wiki/Dan_Houser" title="Dan Houser">Dan Houser</a>
+                    </p>
+                </div>
+
+                <div>
+                    <img src="luyen/Sam_Houser_at_Rockstar_Games.png" alt="Sam Houser">
+                    <p>
+                        <a href="https://en.wikipedia.org/wiki/Sam_Houser" title="Sam Houser">Sam Houser</a>
+                    </p>
+                </div>
+                <p class="caption">
+                    Benzies produced the game alongside Dan Houser, who also co-wrote the story. Sam Houser, president
+                    of Rockstar Games, executive-produced the game.
                 </p>
             </div>
 
-            <div>
-                <img src="luyen/Dan_Houser_at_Rockstar_Games.png" alt="Dan Houser">
-                <p>
-                    <a href="https://en.wikipedia.org/wiki/Dan_Houser" title="Dan Houser">Dan Houser</a>
-                </p>  
-            </div>
-
-            <div>
-                <img src="luyen/Sam_Houser_at_Rockstar_Games.png" alt="Sam Houser">
-                <p>
-                    <a href="https://en.wikipedia.org/wiki/Sam_Houser" title="Sam Houser">Sam Houser</a>
-                </p> 
-            </div>
-            <p class="caption">
-                Benzies produced the game alongside Dan Houser, who also co-wrote the story. Sam Houser, president of Rockstar Games, executive-produced the game.
-            </p>
-        </div>
-
-        <p>
-            <a href="https://en.wikipedia.org/wiki/Rockstar_North" title="Rockstar North">Rockstar North</a>'s core 50-person team led the eighteen-month development of <em>Grand Theft Auto: Vice City</em>.<a href="#footnote15"><sup>[15]</sup></a>
-            Full production began in late 2001, as <a href="" title="Grand Theft Auto III">Grand Theft Auto III</a> was nearing completion;<em></em><a href="#footnote16"><sup>[16]</sup></a> while early development only involved creating <a href="https://en.wikipedia.org/wiki/3D_model" title="3D models">3D models</a>, executive producer <a href="https://en.wikipedia.org/wiki/Sam_Houser" title="Sam Houser">Sam Houser</a> said "it really kicked off at the beginning of 2002" and lasted about nine months.<a href="#footnote17"><sup>[17]</sup></a>
-            After the release of the Windows version of <a href="" title=""></a><em>Grand Theft Auto III</em>, the development team discussed creating a mission pack for the game that would add new weapons, vehicles, and missions.
-            Upon further discussion, the team decided to make this concept a stand-alone game, which became <a href="" title=""></a><em>Vice City</em>.<a href="#footnote18"><sup>[18]</sup></a>
-        </p>
-
-        <p>
-            The game was announced at the <a href="https://en.wikipedia.org/wiki/E3_2002" title="Electronic Entertainment Expo">Electronic Entertainment Expo</a> on 22 May 2002.<a href="#footnote19"><sup>[19]</sup></a>
-            It was Rockstar North's most expensive game at the time, with a development budget of US$5 million<a href="#footnote20"><sup>[20]</sup></a> and marketing budget of US$13.2 million.<a href="#footnote21"><sup>[21]</sup></a>
-            By 15 October 2002, development of <em>Vice City</em> stopped as the game was <a href="https://en.wikipedia.org/wiki/Software_release_life_cycle#Release_to_manufacturing_(RTM)" title="submitted for manufacturing.">submitted for manufacturing.</a><a href="#footnote23"><sup>[23]</sup></a>
-            It was released for the <a href="https://en.wikipedia.org/wiki/PlayStation_2" title="PlayStation 2">PlayStation 2</a> on 29 October 2002 in North America, and on 8 November in Europe.<a href="#footnote24"><sup>[24]</sup></a>
-            <a href="https://en.wikipedia.org/wiki/Capcom" title="Capcom">Capcom</a> published the game in Japan on 20 May 2004 for PlayStation 2 and <a href="" title="Windows.">Windows.</a><a href="#footnote25"><sup>[25]</sup></a>
-            The game was added to the <a href="https://en.wikipedia.org/wiki/Rockstar_Games_Launcher" title="Rockstar Games Launcher">Rockstar Games Launcher</a> in September 2019.<a href="#footnote26"><sup>[26]</sup></a>
-        </p>
-
-    </section>
-
-    <section>
-        <h2>Setting</h2>
-
-        <p>
-            The game is set in 1986 in fictional Vice City, which is based heavily on the city of <a href="https://en.wikipedia.org/wiki/Miami" title="Miami.">Miami.</a><a href="#footnote27"><sup>[27]</sup></a>
-            Vice City previously appeared in the original <a href="https://en.wikipedia.org/wiki/Grand_Theft_Auto_(video_game)" title="Grand Theft Auto">Grand Theft Auto</a> (1997); the development team decided to reuse the location and incorporate ideas from within the studio and the fanbase.<a href="#footnote28"><sup>[28]</sup></a>
-            They wanted to satirise a location that was not contemporary, unlike <em>Grand Theft Auto III</em>'s Liberty City.<a href="#footnote16"><sup>[16]</sup></a>
-            The team wanted to choose a location that had various similarities and differences to <a href="https://en.wikipedia.org/wiki/New_York_City" title="New York City">New York City</a>—the inspiration of Liberty City—eventually leading them to Miami, which producer <a href="https://en.wikipedia.org/wiki/Leslie_Benzies" title="Leslie Benzies">Leslie Benzies</a> describes as "a party town, all sun and sea and sex, but with that same dark edge underneath".<a href="#footnote18"><sup>[18]</sup></a>
-            Sam Houser called it "the grooviest era of crime because it didn't even feel like it was crime ... it was a totally topsy-turvy back-to-front period of time".<a href="#footnote29"><sup>[29]</sup></a>
-            The team intended to make Vice City a "living, breathing city", for the player to feel like "life still goes on" while the character is inside a building.<a href="#footnote30"><sup>[30]</sup></a>
-        </p>
-
-        <p>
-            The game's look, particularly the clothing and vehicles, reflect its 1980s setting.
-            Many themes are borrowed from the crime films <a href="https://en.wikipedia.org/wiki/Scarface_(1983_film)" title="Scarface">Scarface</a> (1983) and <a href="https://en.wikipedia.org/wiki/Carlito%27s_Way" title="Carlito's Way">Carlito's Way</a> (1993),<a href="#footnote27"><sup>[27]</sup></a> the latter for its characterisation and portrayal of nuanced criminals.
-            The television series <a href="https://en.wikipedia.org/wiki/Miami_Vice" title="Miami Vice">Miami Vice</a> (1984–1989) was also a major influence and was regularly watched by the team throughout development.<a href="#footnote31"><sup>[31]</sup></a>
-            Art director Aaron Garbut used the series as a reference point for emulating <a href="https://en.wikipedia.org/wiki/Neon_lighting" title="neon lighting.">neon lighting.</a><a href="#footnote29"><sup>[29]</sup></a>
-            In recreating a 1980s setting, the team found it "relatively painless" due to the distinct culture of the time period and the team's familiarity with the era.[31]
-            The art team was provided with large volumes of research, as well as reference photographs taken by other members of the development team.
-            The team organised field research trips to Miami shortly after completing the development of <em>Grand Theft Auto III</em>, splitting into small teams and observing the streets.<a href="#footnote31"><sup>[31]</sup></a><a href="#footnote32"><sup>[32]</sup></a>
-        </p>
-
-    </section>
-
-    <section>
-        <h1>Story and characters</h1>
-
-        <div class="image-container-dev">
-            <img src="luyen/RayLiottaTIFFSept2012.jpg" alt="Ray Liotta">
             <p>
-                <a href="https://en.wikipedia.org/wiki/Ray_Liotta" title="Ray Liotta">Ray Liotta</a> voiced protagonist <a href="https://en.wikipedia.org/wiki/Tommy_Vercetti" title="Tommy Vercetti">Tommy Vercetti</a>.<a href="#footnote33"><sup>[33]</sup></a>
+                <a href="https://en.wikipedia.org/wiki/Rockstar_North" title="Rockstar North">Rockstar North</a>'s core
+                50-person team led the eighteen-month development of <em>Grand Theft Auto: Vice City</em>.<a
+                    href="#footnote15"><sup>[15]</sup></a>
+                Full production began in late 2001, as <a href="" title="Grand Theft Auto III">Grand Theft Auto III</a>
+                was nearing completion;<em></em><a href="#footnote16"><sup>[16]</sup></a> while early development only
+                involved creating <a href="https://en.wikipedia.org/wiki/3D_model" title="3D models">3D models</a>,
+                executive producer <a href="https://en.wikipedia.org/wiki/Sam_Houser" title="Sam Houser">Sam Houser</a>
+                said "it really kicked off at the beginning of 2002" and lasted about nine months.<a
+                    href="#footnote17"><sup>[17]</sup></a>
+                After the release of the Windows version of <a href="" title=""></a><em>Grand Theft Auto III</em>, the
+                development team discussed creating a mission pack for the game that would add new weapons, vehicles,
+                and missions.
+                Upon further discussion, the team decided to make this concept a stand-alone game, which became <a
+                    href="" title=""></a><em>Vice City</em>.<a href="#footnote18"><sup>[18]</sup></a>
             </p>
-        </div>
 
-        <p>
-            The team spent time "solving [the] riddle" of a speaking protagonist, a notable departure from <em>Grand Theft Auto III</em>'s <a href="https://en.wikipedia.org/wiki/Silent_protagonist" title="silent protagonist">silent protagonist</a> Claude.<a href="#footnote34"><sup>[34]</sup></a>
-            <a href="https://en.wikipedia.org/wiki/Ray_Liotta" title="Ray Liotta">Ray Liotta</a> portrayed protagonist Tommy Vercetti and described the role as challenging: "You're creating a character that's not there before ... It's so intensive".
-            While recording his performance, the team used <a href="https://en.wikipedia.org/wiki/Chroma_key" title="blue screen">blue screen</a> to allow Liotta to visualise "how it's gonna move".<a href="#footnote33"><sup>[33]</sup></a>
-            The team strove to make the player feel a "real affinity" for Tommy by prioritising the game's narrative.<a href="#footnote16"><sup>[16]</sup></a>
-            Dan Houser described Tommy as "strong and dangerous and prepared to wait for the right opportunity to arrive".<a href="#footnote32"><sup>[32]</sup></a>
-            Director <a href="https://en.wikipedia.org/wiki/Navid_Khonsari" title="Navid Khonsari">Navid Khonsari</a> found Liotta occasionally difficult to work with.<a href="#footnote35"><sup>[35]</sup></a>
-            Sam Houser said, "In some sessions he was ... into it, but then sometimes ... he was very dark and couldn't work".<a href="#footnote36"><sup>[36]</sup></a>
-        </p>
+            <p>
+                The game was announced at the <a href="https://en.wikipedia.org/wiki/E3_2002"
+                    title="Electronic Entertainment Expo">Electronic Entertainment Expo</a> on 22 May 2002.<a
+                    href="#footnote19"><sup>[19]</sup></a>
+                It was Rockstar North's most expensive game at the time, with a development budget of US$5 million<a
+                    href="#footnote20"><sup>[20]</sup></a> and marketing budget of US$13.2 million.<a
+                    href="#footnote21"><sup>[21]</sup></a>
+                By 15 October 2002, development of <em>Vice City</em> stopped as the game was <a
+                    href="https://en.wikipedia.org/wiki/Software_release_life_cycle#Release_to_manufacturing_(RTM)"
+                    title="submitted for manufacturing.">submitted for manufacturing.</a><a
+                    href="#footnote23"><sup>[23]</sup></a>
+                It was released for the <a href="https://en.wikipedia.org/wiki/PlayStation_2"
+                    title="PlayStation 2">PlayStation 2</a> on 29 October 2002 in North America, and on 8 November in
+                Europe.<a href="#footnote24"><sup>[24]</sup></a>
+                <a href="https://en.wikipedia.org/wiki/Capcom" title="Capcom">Capcom</a> published the game in Japan on
+                20 May 2004 for PlayStation 2 and <a href="" title="Windows.">Windows.</a><a
+                    href="#footnote25"><sup>[25]</sup></a>
+                The game was added to the <a href="https://en.wikipedia.org/wiki/Rockstar_Games_Launcher"
+                    title="Rockstar Games Launcher">Rockstar Games Launcher</a> in September 2019.<a
+                    href="#footnote26"><sup>[26]</sup></a>
+            </p>
 
-        <p>
-            The majority of the game's animations were original, with only a few borrowed from <em>Grand Theft Auto III</em>.
-            For the characters, the team used <a href="https://en.wikipedia.org/wiki/Motion_capture" title="motion capture">motion capture</a> and <a href="https://en.wikipedia.org/wiki/Stop_motion" title="stop motion">stop motion</a> animation techniques; cutscenes use the former, while gameplay movements use a combination of both techniques.
-            The team encountered difficulty in animating motorcycle animations, due in part to the variety of models.<a href="#footnote37"><sup>[37]</sup></a>
-            Pedestrian character models use <a href="https://en.wikipedia.org/wiki/Skin_(computing)" title="skins">skins</a> in <em>Vice City</em>, allowing the artists to produce more realistic characters.
-            There are 110 unique pedestrian models throughout the game world alongside roughly 50 story characters; each character is rendered using twice the amount of <a href="https://en.wikipedia.org/wiki/Polygon_(computer_graphics)" title="polygons">polygons</a> and <a href="https://en.wikipedia.org/wiki/Texture_mapping" title="textures">textures</a> found in <em>Grand Theft Auto III</em>.<a href="#footnote27"><sup>[27]</sup></a><a href="#footnote32"><sup>[32]</sup></a>
-            The increased polygons also impacted the <a href="https://en.wikipedia.org/wiki/Game_physics" title="character physics">character physics</a>, improving gameplay aspects such as weapon-hit accuracy.<a href="#footnote38"><sup>[38]</sup></a>
-            Some character models and storylines were inspired by films such as <a href="https://en.wikipedia.org/wiki/The_Godfather" title="The Godfather">The Godfather</a> (1972), and the game's presentation was inspired by <a href="https://en.wikipedia.org/wiki/Action_film" title="action">action</a> television shows of the 1980s.<a href="#footnote39"><sup>[39]</sup></a>
-            The interplay between Tommy Vercetti and Lance Vance was crafted to be similar to the relationship of <em>Miami Vice</em>'s <a href="https://en.wikipedia.org/wiki/Sonny_Crockett" title="Sonny Crockett">Sonny Crockett</a> and <a href="https://en.wikipedia.org/wiki/Ricardo_Tubbs" title="Ricardo Tubbs">Ricardo Tubbs</a>.<a href="#footnote40"><sup>[40]</sup></a>
-        </p>
+        </section>
 
-    </section>
+        <section>
+            <h2>Setting</h2>
 
-    <section>
-        <h2>Sound design and music production</h2>
-        
-        <p>
-            The game features 8,000 lines of recorded dialogue, four times the amount in <em>Grand Theft Auto III.</em><a href="#footnote32"><sup>[32]</sup></a>
-            It contains over 90 minutes of <a href="https://en.wikipedia.org/wiki/Cutscene" title="cutscenes">cutscenes</a> and nine hours of music,<a href="#footnote32"><sup>[32]</sup></a> with more than 113 songs and commercials.<a href="#footnote41"><sup>[41]</sup></a>
-            The team enjoyed the challenge of creating the game's soundtrack, particularly in contrast to <em>Grand Theft Auto III</em>'s music, which Sam Houser described as "clearly satirical and its own thing".<a href="#footnote17"><sup>[17]</sup></a>
-            In developing the radio stations, the team wanted to reinforce the game's setting by collating a variety of songs from the 1980s, which required extensive research.<a href="#footnote42"><sup>[42]</sup></a>
-            The radio stations were published by <a href="https://en.wikipedia.org/wiki/Epic_Records" title="Epic Records">Epic Records</a> in seven albums—known collectively as <em>Grand Theft Auto: Vice City Official Soundtrack Box Set</em>—alongside the game in October 2002.<a href="#footnote43"><sup>[43]</sup></a><a href="#footnote44"><sup>[44]</sup></a>
-            <em>Vice City</em> contains about "three times as much" <a href="https://en.wikipedia.org/wiki/Talk_radio" title="talk radio">talk radio</a> as <em>Grand Theft Auto III</em>.
-            Producer and talk show host <a href="https://en.wikipedia.org/wiki/Lazlow_Jones" title="Lazlow Jones">Lazlow Jones</a> stated that the small percentage of station listeners that actually <a href="https://en.wikipedia.org/wiki/Phone-in" title="call in">call in</a> are "insane"; in <em>Vice City</em>, the developers "bumped it up a notch", emphasising the extremity.
-            Dan Houser felt that the talk stations give depth to the game world.<a href="#footnote45"><sup>[45]</sup></a>
-        </p>
+            <p>
+                The game is set in 1986 in fictional Vice City, which is based heavily on the city of <a
+                    href="https://en.wikipedia.org/wiki/Miami" title="Miami.">Miami.</a><a
+                    href="#footnote27"><sup>[27]</sup></a>
+                Vice City previously appeared in the original <a
+                    href="https://en.wikipedia.org/wiki/Grand_Theft_Auto_(video_game)" title="Grand Theft Auto">Grand
+                    Theft Auto</a> (1997); the development team decided to reuse the location and incorporate ideas from
+                within the studio and the fanbase.<a href="#footnote28"><sup>[28]</sup></a>
+                They wanted to satirise a location that was not contemporary, unlike <em>Grand Theft Auto III</em>'s
+                Liberty City.<a href="#footnote16"><sup>[16]</sup></a>
+                The team wanted to choose a location that had various similarities and differences to <a
+                    href="https://en.wikipedia.org/wiki/New_York_City" title="New York City">New York City</a>—the
+                inspiration of Liberty City—eventually leading them to Miami, which producer <a
+                    href="https://en.wikipedia.org/wiki/Leslie_Benzies" title="Leslie Benzies">Leslie Benzies</a>
+                describes as "a party town, all sun and sea and sex, but with that same dark edge underneath".<a
+                    href="#footnote18"><sup>[18]</sup></a>
+                Sam Houser called it "the grooviest era of crime because it didn't even feel like it was crime ... it
+                was a totally topsy-turvy back-to-front period of time".<a href="#footnote29"><sup>[29]</sup></a>
+                The team intended to make Vice City a "living, breathing city", for the player to feel like "life still
+                goes on" while the character is inside a building.<a href="#footnote30"><sup>[30]</sup></a>
+            </p>
 
-    </section>
+            <p>
+                The game's look, particularly the clothing and vehicles, reflect its 1980s setting.
+                Many themes are borrowed from the crime films <a
+                    href="https://en.wikipedia.org/wiki/Scarface_(1983_film)" title="Scarface">Scarface</a> (1983) and
+                <a href="https://en.wikipedia.org/wiki/Carlito%27s_Way" title="Carlito's Way">Carlito's Way</a>
+                (1993),<a href="#footnote27"><sup>[27]</sup></a> the latter for its characterisation and portrayal of
+                nuanced criminals.
+                The television series <a href="https://en.wikipedia.org/wiki/Miami_Vice" title="Miami Vice">Miami
+                    Vice</a> (1984–1989) was also a major influence and was regularly watched by the team throughout
+                development.<a href="#footnote31"><sup>[31]</sup></a>
+                Art director Aaron Garbut used the series as a reference point for emulating <a
+                    href="https://en.wikipedia.org/wiki/Neon_lighting" title="neon lighting.">neon lighting.</a><a
+                    href="#footnote29"><sup>[29]</sup></a>
+                In recreating a 1980s setting, the team found it "relatively painless" due to the distinct culture of
+                the time period and the team's familiarity with the era.[31]
+                The art team was provided with large volumes of research, as well as reference photographs taken by
+                other members of the development team.
+                The team organised field research trips to Miami shortly after completing the development of <em>Grand
+                    Theft Auto III</em>, splitting into small teams and observing the streets.<a
+                    href="#footnote31"><sup>[31]</sup></a><a href="#footnote32"><sup>[32]</sup></a>
+            </p>
+
+        </section>
+
+        <section>
+            <h1>Story and characters</h1>
+
+            <div class="image-container-dev">
+                <img src="luyen/RayLiottaTIFFSept2012.jpg" alt="Ray Liotta">
+                <p>
+                    <a href="https://en.wikipedia.org/wiki/Ray_Liotta" title="Ray Liotta">Ray Liotta</a> voiced
+                    protagonist <a href="https://en.wikipedia.org/wiki/Tommy_Vercetti" title="Tommy Vercetti">Tommy
+                        Vercetti</a>.<a href="#footnote33"><sup>[33]</sup></a>
+                </p>
+            </div>
+
+            <p>
+                The team spent time "solving [the] riddle" of a speaking protagonist, a notable departure from <em>Grand
+                    Theft Auto III</em>'s <a href="https://en.wikipedia.org/wiki/Silent_protagonist"
+                    title="silent protagonist">silent protagonist</a> Claude.<a href="#footnote34"><sup>[34]</sup></a>
+                <a href="https://en.wikipedia.org/wiki/Ray_Liotta" title="Ray Liotta">Ray Liotta</a> portrayed
+                protagonist Tommy Vercetti and described the role as challenging: "You're creating a character that's
+                not there before ... It's so intensive".
+                While recording his performance, the team used <a href="https://en.wikipedia.org/wiki/Chroma_key"
+                    title="blue screen">blue screen</a> to allow Liotta to visualise "how it's gonna move".<a
+                    href="#footnote33"><sup>[33]</sup></a>
+                The team strove to make the player feel a "real affinity" for Tommy by prioritising the game's
+                narrative.<a href="#footnote16"><sup>[16]</sup></a>
+                Dan Houser described Tommy as "strong and dangerous and prepared to wait for the right opportunity to
+                arrive".<a href="#footnote32"><sup>[32]</sup></a>
+                Director <a href="https://en.wikipedia.org/wiki/Navid_Khonsari" title="Navid Khonsari">Navid
+                    Khonsari</a> found Liotta occasionally difficult to work with.<a
+                    href="#footnote35"><sup>[35]</sup></a>
+                Sam Houser said, "In some sessions he was ... into it, but then sometimes ... he was very dark and
+                couldn't work".<a href="#footnote36"><sup>[36]</sup></a>
+            </p>
+
+            <p>
+                The majority of the game's animations were original, with only a few borrowed from <em>Grand Theft Auto
+                    III</em>.
+                For the characters, the team used <a href="https://en.wikipedia.org/wiki/Motion_capture"
+                    title="motion capture">motion capture</a> and <a href="https://en.wikipedia.org/wiki/Stop_motion"
+                    title="stop motion">stop motion</a> animation techniques; cutscenes use the former, while gameplay
+                movements use a combination of both techniques.
+                The team encountered difficulty in animating motorcycle animations, due in part to the variety of
+                models.<a href="#footnote37"><sup>[37]</sup></a>
+                Pedestrian character models use <a href="https://en.wikipedia.org/wiki/Skin_(computing)"
+                    title="skins">skins</a> in <em>Vice City</em>, allowing the artists to produce more realistic
+                characters.
+                There are 110 unique pedestrian models throughout the game world alongside roughly 50 story characters;
+                each character is rendered using twice the amount of <a
+                    href="https://en.wikipedia.org/wiki/Polygon_(computer_graphics)" title="polygons">polygons</a> and
+                <a href="https://en.wikipedia.org/wiki/Texture_mapping" title="textures">textures</a> found in <em>Grand
+                    Theft Auto III</em>.<a href="#footnote27"><sup>[27]</sup></a><a
+                    href="#footnote32"><sup>[32]</sup></a>
+                The increased polygons also impacted the <a href="https://en.wikipedia.org/wiki/Game_physics"
+                    title="character physics">character physics</a>, improving gameplay aspects such as weapon-hit
+                accuracy.<a href="#footnote38"><sup>[38]</sup></a>
+                Some character models and storylines were inspired by films such as <a
+                    href="https://en.wikipedia.org/wiki/The_Godfather" title="The Godfather">The Godfather</a> (1972),
+                and the game's presentation was inspired by <a href="https://en.wikipedia.org/wiki/Action_film"
+                    title="action">action</a> television shows of the 1980s.<a href="#footnote39"><sup>[39]</sup></a>
+                The interplay between Tommy Vercetti and Lance Vance was crafted to be similar to the relationship of
+                <em>Miami Vice</em>'s <a href="https://en.wikipedia.org/wiki/Sonny_Crockett"
+                    title="Sonny Crockett">Sonny Crockett</a> and <a href="https://en.wikipedia.org/wiki/Ricardo_Tubbs"
+                    title="Ricardo Tubbs">Ricardo Tubbs</a>.<a href="#footnote40"><sup>[40]</sup></a>
+            </p>
+
+        </section>
+
+        <section>
+            <h2>Sound design and music production</h2>
+
+            <p>
+                The game features 8,000 lines of recorded dialogue, four times the amount in <em>Grand Theft Auto
+                    III.</em><a href="#footnote32"><sup>[32]</sup></a>
+                It contains over 90 minutes of <a href="https://en.wikipedia.org/wiki/Cutscene"
+                    title="cutscenes">cutscenes</a> and nine hours of music,<a href="#footnote32"><sup>[32]</sup></a>
+                with more than 113 songs and commercials.<a href="#footnote41"><sup>[41]</sup></a>
+                The team enjoyed the challenge of creating the game's soundtrack, particularly in contrast to <em>Grand
+                    Theft Auto III</em>'s music, which Sam Houser described as "clearly satirical and its own thing".<a
+                    href="#footnote17"><sup>[17]</sup></a>
+                In developing the radio stations, the team wanted to reinforce the game's setting by collating a variety
+                of songs from the 1980s, which required extensive research.<a href="#footnote42"><sup>[42]</sup></a>
+                The radio stations were published by <a href="https://en.wikipedia.org/wiki/Epic_Records"
+                    title="Epic Records">Epic Records</a> in seven albums—known collectively as <em>Grand Theft Auto:
+                    Vice City Official Soundtrack Box Set</em>—alongside the game in October 2002.<a
+                    href="#footnote43"><sup>[43]</sup></a><a href="#footnote44"><sup>[44]</sup></a>
+                <em>Vice City</em> contains about "three times as much" <a
+                    href="https://en.wikipedia.org/wiki/Talk_radio" title="talk radio">talk radio</a> as <em>Grand Theft
+                    Auto III</em>.
+                Producer and talk show host <a href="https://en.wikipedia.org/wiki/Lazlow_Jones"
+                    title="Lazlow Jones">Lazlow Jones</a> stated that the small percentage of station listeners that
+                actually <a href="https://en.wikipedia.org/wiki/Phone-in" title="call in">call in</a> are "insane"; in
+                <em>Vice City</em>, the developers "bumped it up a notch", emphasising the extremity.
+                Dan Houser felt that the talk stations give depth to the game world.<a
+                    href="#footnote45"><sup>[45]</sup></a>
+            </p>
+
+        </section>
     </main>
     <!-- Footer: contain references -->
     <div class="border-overlay"></div>
     <footer class="container">
-    <h2>References</h2>
-
+        <h2>References</h2>
+        <ul>
+            <li id="footnote15"><strong>[15]</strong> Leland, John (27 October 2002). <a
+                    href="http://www.nytimes.com/2002/10/27/style/bigger-bolder-faster-weirder.html?pagewanted=2">"Bigger,
+                    Bolder, Faster, Weirder"</a>. The New York Times. p. 2.</li>
+            <li id="footnote16"><strong>[16]</strong> <a
+                    href="https://web.archive.org/web/20111105233001/http://designmuseum.org/design/rockstar-games">"Rockstar
+                    Games – Design/Designer Information"</a>. Design Museum.</li>
+            <li id="footnote17"><strong>[17]</strong> <a
+                    href="https://web.archive.org/web/20121210064842/http://www.edge-online.com/features/the-making-of-grand-theft-auto-vice-city/2">"The
+                    Making Of Grand Theft Auto: Vice City"</a>. Edge. Future plc. 7 December 2012. p. 2.</li>
+            <li id="footnote18"><strong>[18]</strong> Rosenberg, Adam (13 December 2012). <a
+                    href="http://www.digitaltrends.com/gaming/exploring-grand-theft-auto-vice-citys-lasting-impact-on-gamer-culture-with-rockstars-leslie-benzies/">"Exploring
+                    Grand Theft Auto: Vice City's lasting impact on society with Rockstar's Leslie Benzies"</a>. Digital
+                Trends.</li>
+            <li id="footnote19"><strong>[19]</strong> Walker, Trey (22 May 2002). <a
+                    href="http://www.gamespot.com/articles/e3-2002-grand-theft-auto-vice-city-announced/1100-2866693/">"E3
+                    2002: Grand Theft Auto: Vice City announced"</a>. GameSpot. CBS Interactive.</li>
+            <li id="footnote20"><strong>[20]</strong> <a
+                    href="https://en.wikipedia.org/wiki/Grand_Theft_Auto:_Vice_City#CITEREFKushner2012">Kushner 2012, p.
+                    117.</a></li>
+            <li id="footnote21"><strong>[21]</strong> Parisi, Paula (10 August 2004). <a
+                    href="https://en.wikipedia.org/wiki/The_Hollywood_Reporter">"Game points"</a>. The Hollywood
+                Reporter. Vol. 385, no. 7. Billboard Media LLC. Gale A121283480.</li>
+            <li id="footnote23"><strong>[23]</strong> Calvert, Justin (15 October 2002). <a
+                    href="http://www.gamespot.com/articles/gta-vice-city-goes-gold/1100-2894689/">"GTA: Vice City goes
+                    gold"</a>. GameSpot. CBS Interactive.</li>
+            <li id="footnote24"><strong>[24]</strong> <a
+                    href="https://web.archive.org/web/20220523081609/https://ir.take2games.com/news-releases/news-release-details/rockstar-games-ships-grand-theft-auto-vice-city-playstation-r-2">"Rockstar
+                    Games Ships Grand Theft Auto: Vice City for PlayStation-R-2 Computer Entertainment System"</a>
+                (Press release). Take-Two Interactive. 29 October 2002.</li>
+            <li id="footnote25"><strong>[25]</strong> Hitmitsu, Suppai (23 April 2004). <a
+                    href="https://www.ign.com/articles/2004/04/22/capcom-announces-vice-city-campaign">"Capcom Announces
+                    Vice City Campaign"</a>. IGN. Ziff Davis.</li>
+            <li id="footnote26"><strong>[26]</strong> McAloon, Alissa (17 September 2019). <a
+                    href="https://www.gamasutra.com/view/news/350814/Rockstar_Games_now_has_its_own_game_launcher_on_PC.php">"Rockstar
+                    Games now has its own game launcher on PC"</a>. Gamasutra. UBM Technology Group.</li>
+            <li id="footnote27"><strong>[27]</strong> <a
+                    href="http://www.gamespot.com/articles/grand-theft-auto-vice-city-graphics-qanda/1100-2881042/">"Grand
+                    Theft Auto: Vice City Graphics Q&A"</a>. GameSpot. CBS Interactive. 20 September 2002.</li>
+            <li id="footnote28"><strong>[28]</strong> Sulic, Ivan; Perry, Doug (7 April 2003). <a
+                    href="https://ign.com/articles/2003/04/07/inside-vice-city?page=2">"Inside Vice City"</a>. IGN. Ziff
+                Davis. p. 2.</li>
+            <li id="footnote29"><strong>[29]</strong> <a
+                    href="https://web.archive.org/web/20121209050201/http://www.edge-online.com/features/the-making-of-grand-theft-auto-vice-city/">"The
+                    Making Of Grand Theft Auto: Vice City"</a>. Edge. Future plc. 7 December 2012. p. 1.</li>
+            <li id="footnote30"><strong>[30]</strong> <a
+                    href="http://www.gamespot.com/articles/grand-theft-auto-vice-city-interaction-qanda/1100-2895857/">"Grand
+                    Theft Auto: Vice City Interaction Q&A"</a>. GameSpot. CBS Interactive. 25 October 2002.</li>
+            <li id="footnote31"><strong>[31]</strong> Norris, Erik (6 December 2012). <a
+                    href="https://web.archive.org/web/20161220150207/http://www.craveonline.com/site/201175-missing-you-looking-back-at-gta-vice-city-w-rockstar-games">"Missing
+                    You: Looking Back at GTA: Vice City w/ Rockstar Games"</a>. CraveOnline. Atomic Media.</li>
+            <li id="footnote32"><strong>[32]</strong> Perry, Douglass C. (October 2002). <a href="#">"Grand Theft Auto:
+                    Vice City"</a>. IGN Unplugged (17). Ziff Davis: 8–15.</li>
+            <li id="footnote33"><strong>[33]</strong> <a
+                    href="https://ign.com/articles/2002/10/25/the-voice-of-vice-city">"The Voice of Vice City"</a>. IGN.
+                Ziff Davis. 25 October 2002.</li>
+            <li id="footnote34"><strong>[34]</strong> McInnis, Shaun (21 October 2011). <a
+                    href="http://www.gamespot.com/articles/dan-houser-opens-up-about-grand-theft-auto-iii/1100-6341347/">"Dan
+                    Houser Opens Up About Grand Theft Auto III"</a>. GameSpot. CBS Interactive.</li>
+            <li id="footnote35"><strong>[35]</strong> <a
+                    href="https://en.wikipedia.org/wiki/Grand_Theft_Auto:_Vice_City#CITEREFKushner2012">Kushner 2012, p.
+                    118.</a></li>
+            <li id="footnote36"><strong>[36]</strong> <a
+                    href="https://gamesradar.com/sam-houser-gta-iv-crazier-than-ever/2/">"Sam Houser: "</a>GTA IV
+                crazier than ever"". GamesRadar. Future plc. 11 March 2008.</li>
+            <li id="footnote37"><strong>[37]</strong> <a
+                    href="http://www.gamespot.com/articles/grand-theft-auto-vice-city-animation-qanda/1100-2882501/">"Grand
+                    Theft Auto: Vice City Animation Q&A"</a>. GameSpot. CBS Interactive. 28 February 2003.</li>
+            <li id="footnote38"><strong>[38]</strong> <a
+                    href="http://www.gamespot.com/articles/grand-theft-auto-vice-city-physics-qanda/1100-2881862/">"Grand
+                    Theft Auto: Vice City Physics Q&A"</a>. GameSpot. CBS Interactive. 15 March 2003.</li>
+            <li id="footnote39"><strong>[39]</strong> Sulic, Ivan; Perry, Doug (7 April 2003). <a
+                    href="https://ign.com/articles/2003/04/07/inside-vice-city">"Inside Vice City"</a>. IGN. Ziff Davis.
+                p. 1.</li>
+            <li id="footnote40"><strong>[40]</strong> <a
+                    href="https://web.archive.org/web/20121210064852/http://www.edge-online.com/features/the-making-of-grand-theft-auto-vice-city/4">"The
+                    Making Of Grand Theft Auto: Vice City"</a>. Edge. Future plc. 7 December 2012. p. 4.</li>
+            <li id="footnote41"><strong>[41]</strong> Sulic, Ivan; Perry, Doug (7 April 2003). <a
+                    href="https://ign.com/articles/2003/04/07/inside-vice-city?page=4">"Inside Vice City"</a>. IGN. Ziff
+                Davis. p. 4.</li>
+            <li id="footnote42"><strong>[42]</strong> Skipper, Ben (3 March 2015). <a
+                    href="http://www.ibtimes.co.uk/former-rockstar-music-director-explains-how-gta-radio-soundtracks-are-put-together-1490252">"Former
+                    Rockstar music director explains how GTA radio soundtracks are put together"</a>. International
+                Business Times. IBT Media.</li>
+            <li id="footnote43"><strong>[43]</strong> Calvert, Justin (10 September 2002). <a
+                    href="http://www.gamespot.com/articles/gta-vice-city-to-be-released-alongside-soundtracks/1100-2879673/">"GTA:
+                    Vice City to be released alongside soundtracks"</a>. GameSpot. CBS Interactive.</li>
+            <li id="footnote44"><strong>[44]</strong> Calvert, Justin (3 October 2002). <a
+                    href="http://www.gamespot.com/articles/gta-vice-city-soundtrack-cd-rom-details/1100-2882302/">"GTA:
+                    Vice City soundtrack CD-ROM details"</a>. GameSpot. CBS Interactive.</li>
+            <li id="footnote45"><strong>[45]</strong> <a
+                    href="http://www.gamespot.com/articles/grand-theft-auto-vice-city-talk-radio-qanda/1100-2895111/">"Grand
+                    Theft Auto: Vice City Talk Radio Q&A"</a>. GameSpot. CBS Interactive. 20 November 2003.</li>
+        </ul>
     </footer>
 </body>
+
 </html>

--- a/legacy.html
+++ b/legacy.html
@@ -1,311 +1,332 @@
 <!DOCTYPE html>
 <html lang="en">
-    
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Legacy</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="test/styles.css">
+    <link rel="stylesheet" href="Test/styles.css">
 </head>
+
 <body>
 
-<!-- Navigation Bar -->
-<nav class="navbar navbar-expand-lg fixed-top bg-transparent">
-    <div class="container-fluid">
-        <a class="navbar-brand text-white" href="#">Vice City</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarNav">
-            <ul class="navbar-nav">
-                <li class="nav-item"><a class="nav-link text-white" href="test/index.html">HOME</a></li>
-                        <li class="nav-item"><a class="nav-link text-white" href="ABOUT_UPDATE_1.html">ABOUT</a></li>
-                        <li class="nav-item"><a class="nav-link text-white" href="development.html">DEVELOPMENT</a></li>
-                        <li class="nav-item"><a class="nav-link text-white" href="reception.html">RECEPTION</a></li>
-                        <li class="nav-item"><a class="nav-link text-white" href="legacy.html">LEGACY</a></li>
-            </ul>
+    <!-- Navigation Bar -->
+    <nav class="navbar navbar-expand-lg fixed-top bg-transparent">
+        <div class="container-fluid">
+            <a class="navbar-brand text-white" href="#">Vice City</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav">
+                    <li class="nav-item"><a class="nav-link text-white" href="test/index.html">HOME</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="ABOUT_UPDATE_1.html">ABOUT</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="development.html">DEVELOPMENT</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="reception.html">RECEPTION</a></li>
+                    <li class="nav-item"><a class="nav-link text-white" href="legacy.html">LEGACY</a></li>
+                </ul>
+            </div>
         </div>
-    </div>
-</nav>
-   
+    </nav>
+
     <!-- Main Content -->
     <main>
         <div class="container mt-5 pt-5">
             <div class="row">
                 <div class="col">
                     <p>
-                        <i><b>Grand Theft Auto: Vice City</b></i> is a 2002 action-adventure game developed by Rockstar North and published by Rockstar Games. It is the fourth main game in the Grand Theft Auto series, following 2001's Grand Theft Auto III, and the sixth entry overall. Set in 1986 within the fictional Vice City (based on Miami and Miami Beach), the single-player story follows mobster Tommy Vercetti's rise to power after being released from prison and becoming caught up in an ambushed drug deal.
+                        <i><b>Grand Theft Auto: Vice City</b></i> is a 2002 action-adventure game developed by Rockstar
+                        North and published by Rockstar Games. It is the fourth main game in the Grand Theft Auto
+                        series, following 2001's Grand Theft Auto III, and the sixth entry overall. Set in 1986 within
+                        the fictional Vice City (based on Miami and Miami Beach), the single-player story follows
+                        mobster Tommy Vercetti's rise to power after being released from prison and becoming caught up
+                        in an ambushed drug deal.
                     </p>
                 </div>
             </div>
-    <section>
-        <h1>Legacy</h1>
+            <section>
+                <h1>Legacy</h1>
 
-        <blockquote>
-            ...Each month a freelancer sails into Vice City and moors his yacht. He sells his cargo to the first boat. 
-            I want you to take the speedboat and beat all the other shitheads to it, then you bring the cargo here, ok!? <br>
-            — Ricardo Diaz
-        </blockquote>
+                <blockquote>
+                    ...Each month a freelancer sails into Vice City and moors his yacht. He sells his cargo to the first
+                    boat.
+                    I want you to take the speedboat and beat all the other shitheads to it, then you bring the cargo
+                    here, ok!? <br>
+                    — Ricardo Diaz
+                </blockquote>
 
-        <!-- I've just copied and pasted the Legacy content from the Wikipedia page, but added things like italics, links and footnotes -->
-        <!-- Added <sup> tags to make the footnotes smaller and raised to look like traditional footnotes -->
-        <p> Mike Snider of <a href=”https://en.wikipedia.org/wiki/USA_Today” title="USA Today"><em>USA Today</em></a> wrote that <em>Vice City</em> "raised the bar for video games", citing its interactivity, violence, 
-        and soundtrack.<a href="#footnote122"><sup>[122]</sup></a> 
-        <a href=”https://en.wikipedia.org/wiki/Kotaku” title=”Kotaku”><em>Kotaku</em></a>'s Luke Plunkett 
-        and <a href=”https://en.wikipedia.org/wiki/PCMag” title="PC Magazine">PC Magazine</a>'s 
-        Jeffrey L. Wilson both named </em>Vice City</em> 
-        the best game in the series, with the former naming it the "perfect Grand Theft 
-        Auto experience".<a href="#footnote123"><sup>[123]</sup></a><a href="#footnote124"><sup>[124]</sup></a>
-        The readers of <a href=”https://en.wikipedia.org/wiki/PlayStation_Official_Magazine_%E2%80%93_UK” title=”Official UK PlayStation Magazine”>Official UK PlayStation Magazine</a> 
-        named <em>Vice City</em> the fourth-greatest PlayStation 
-        title ever released.<a href="#footnote125"><sup>[125]</sup></a> 
-        In 2006 <em>Vice City</em> appeared on Japanese magazine Famitsu's readers' list of top 100 games; it was one of the only Western titles 
-        on the list.<a href="#footnote126"><sup>[126]</sup></a> 
-        Art director Aaron Garbut felt that, alongside its predecessor <em>Grand Theft Auto III</em> and 
-        successor <em>San Andreas</em>, <em>Vice City</em> led the trend of open world games.<a href="#footnote31"><sup>[31]</sup></a>
-        A new rendition of Vice City is set to return in <em>Grand Theft Auto VI</em> (2025).<a href="#footnote127"><sup>[127]</sup></a></p>
-    </section>
+                <!-- I've just copied and pasted the Legacy content from the Wikipedia page, but added things like italics, links and footnotes -->
+                <!-- Added <sup> tags to make the footnotes smaller and raised to look like traditional footnotes -->
+                <p> Mike Snider of <a href=”https://en.wikipedia.org/wiki/USA_Today” title="USA Today"><em>USA
+                            Today</em></a> wrote that <em>Vice City</em> "raised the bar for video games", citing its
+                    interactivity, violence,
+                    and soundtrack.<a href="#footnote122"><sup>[122]</sup></a>
+                    <a href=”https://en.wikipedia.org/wiki/Kotaku” title=”Kotaku”><em>Kotaku</em></a>'s Luke Plunkett
+                    and <a href=”https://en.wikipedia.org/wiki/PCMag” title="PC Magazine">PC Magazine</a>'s
+                    Jeffrey L. Wilson both named </em>Vice City</em>
+                    the best game in the series, with the former naming it the "perfect Grand Theft
+                    Auto experience".<a href="#footnote123"><sup>[123]</sup></a><a
+                        href="#footnote124"><sup>[124]</sup></a>
+                    The readers of <a href=”https://en.wikipedia.org/wiki/PlayStation_Official_Magazine_%E2%80%93_UK”
+                        title=”Official UK PlayStation Magazine”>Official UK PlayStation Magazine</a>
+                    named <em>Vice City</em> the fourth-greatest PlayStation
+                    title ever released.<a href="#footnote125"><sup>[125]</sup></a>
+                    In 2006 <em>Vice City</em> appeared on Japanese magazine Famitsu's readers' list of top 100 games;
+                    it was one of the only Western titles
+                    on the list.<a href="#footnote126"><sup>[126]</sup></a>
+                    Art director Aaron Garbut felt that, alongside its predecessor <em>Grand Theft Auto III</em> and
+                    successor <em>San Andreas</em>, <em>Vice City</em> led the trend of open world games.<a
+                        href="#footnote31"><sup>[31]</sup></a>
+                    A new rendition of Vice City is set to return in <em>Grand Theft Auto VI</em> (2025).<a
+                        href="#footnote127"><sup>[127]</sup></a>
+                </p>
+            </section>
 
-    <section>
-    <h2>Ports</h2>
+            <section>
+                <h2>Ports</h2>
 
-        <p> 
-            <em>Grand Theft Auto: Vice City</em> was released for Windows on 13 May 2003 in North America 
-            and 16 May in Europe,<a href="#footnote128"><sup>[128]</sup></a> supporting higher 
-            screen resolutions and draw distance, and featuring more detailed textures.<a href="#footnote129"><sup>[129]</sup></a> 
-            <em>Vice City</em> was bundled with <em>Grand Theft Auto III</em> in a compilation titled <em>Grand Theft Auto: Double Pack</em>, 
-            released on the Xbox on 4 November 2003 in North America<a href="#footnote130"><sup>[130]</sup></a> and 2 January 2004 
-            in Europe.<a href="#footnote131"><sup>[131]</sup></a> 
-            The Xbox version featured a custom soundtrack support as well as improved audio, polygon models, and reflections over the 
-            previous ports.<a href="#footnote132"><sup>[132]</sup></a>
-            <em>Double Pack</em> was later bundled with <em>San Andreas</em> in a compilation titled <a href=”https://en.wikipedia.org/wiki/Grand_Theft_Auto#Compilations” title="Grand Theft Auto: The Trilogy"><em>Grand Theft Auto: The Trilogy</em></a>, released 
-            in October 2005.<a href="#footnote133"><sup>[133]</sup></a> Analysts believed that the game would eventually release 
-            on GameCube,<a href="#footnote134"><sup>[134]</sup></a> though it never materialised.<a href="#footnote135"><sup>[135]</sup></a> <em>The Trilogy</em> 
-            was also released for OS X on 12 November 2010.<a href="#footnote136"><sup>[136]</sup></a>
-        </p>
+                <p>
+                    <em>Grand Theft Auto: Vice City</em> was released for Windows on 13 May 2003 in North America
+                    and 16 May in Europe,<a href="#footnote128"><sup>[128]</sup></a> supporting higher
+                    screen resolutions and draw distance, and featuring more detailed textures.<a
+                        href="#footnote129"><sup>[129]</sup></a>
+                    <em>Vice City</em> was bundled with <em>Grand Theft Auto III</em> in a compilation titled <em>Grand
+                        Theft Auto: Double Pack</em>,
+                    released on the Xbox on 4 November 2003 in North America<a href="#footnote130"><sup>[130]</sup></a>
+                    and 2 January 2004
+                    in Europe.<a href="#footnote131"><sup>[131]</sup></a>
+                    The Xbox version featured a custom soundtrack support as well as improved audio, polygon models, and
+                    reflections over the
+                    previous ports.<a href="#footnote132"><sup>[132]</sup></a>
+                    <em>Double Pack</em> was later bundled with <em>San Andreas</em> in a compilation titled <a
+                        href=”https://en.wikipedia.org/wiki/Grand_Theft_Auto#Compilations”
+                        title="Grand Theft Auto: The Trilogy"><em>Grand Theft Auto: The Trilogy</em></a>, released
+                    in October 2005.<a href="#footnote133"><sup>[133]</sup></a> Analysts believed that the game would
+                    eventually release
+                    on GameCube,<a href="#footnote134"><sup>[134]</sup></a> though it never materialised.<a
+                        href="#footnote135"><sup>[135]</sup></a> <em>The Trilogy</em>
+                    was also released for OS X on 12 November 2010.<a href="#footnote136"><sup>[136]</sup></a>
+                </p>
 
-        <style>
-            .image-container-dev img {
-                transition: transform 0.3s ease;
-            }
-            
-            .image-container-dev img:hover {
-                transform: scale(1.07); 
-            }
-        </style>
+                <style>
+                    .image-container-dev img {
+                        transition: transform 0.3s ease;
+                    }
 
-        <div class="image-container-dev" style="display: flex; justify-content: center;">
-            <div>
-                <img 
-                    src="https://static.wikia.nocookie.net/gtawiki/images/b/b1/TheTwins-Artwork2.jpg/revision/latest?cb=20181230221317" 
-                    alt="The Twins - GTA Artwork"
-                    width="600" 
-                    height="338">
-                    <a href="https://gta.fandom.com/wiki/The_Twins" 
-                       title="The Twins (GTA)">
-                    </a>
-            </div>
-        </div>
+                    .image-container-dev img:hover {
+                        transform: scale(1.07);
+                    }
+                </style>
 
-        <p>
-            For its tenth anniversary in 2012, <em>Vice City</em> was ported to mobile devices by War Drum Studios, building on the Windows version with 
-            enhanced visuals and a customisable layout.<a href="#footnote64"><sup>[64]</sup></a> It was released for iOS devices on 6 
-            December,<a href="#footnote137"><sup>[137]</sup></a>
-            for Android on 12 December following a delay due to technical issues,<a href="#footnote138"><sup>[138]</sup></a> and for Fire OS on 
-            15 May 2014.<a href="#footnote139"><sup>[139]</sup></a> An emulated version of <em>Vice City</em> was released on the PlayStation 3 
-            on 30 January 2013 via the PlayStation Network's PS2 Classics;<a href="#footnote135"><sup>[140]</sup></a> another emulated version was 
-            released for the PlayStation 4 on 5 December 2015, upscaled to 1080p and with support for Trophies.<a href="#footnote141"><sup>[141]</sup></a> A 
-            remastered version of The Trilogy, subtitled <a href=”https://en.wikipedia.org/wiki/Grand_Theft_Auto:_The_Trilogy_%E2%80%93_The_Definitive_Edition” title=”The Definitive Edition”><em>The Definitive Edition</em></a>, 
-            was released for the Nintendo Switch, PlayStation 4, 
-            PlayStation 5, Windows, Xbox One, and Xbox Series X/S on 11 November 2021,<a href="#footnote142"><sup>[142]</sup></a> and for Android and iOS on 
-            14 December 2023.<a href="#footnote143"><sup>[143]</sup></a> The original game was removed 
-            from digital retailers in preparation for <em>The Definitive Edition</em>,<a href="#footnote142"><sup>[142]</sup></a> 
-            but later restored as a bundle on the Rockstar Store.<a href="#footnote144"><sup>[144]</sup></a>
-        </p>
+                <div class="image-container-dev" style="display: flex; justify-content: center;">
+                    <div>
+                        <img src="https://static.wikia.nocookie.net/gtawiki/images/b/b1/TheTwins-Artwork2.jpg/revision/latest?cb=20181230221317"
+                            alt="The Twins - GTA Artwork" width="600" height="338">
+                        <a href="https://gta.fandom.com/wiki/The_Twins" title="The Twins (GTA)">
+                        </a>
+                    </div>
+                </div>
 
-        <p>
-            A core team of six fans reverse-engineered the game and released it as an executable in December 2020, having worked on it since May; 
-            titled <em>reVC</em>, the project allows the game to be unofficially ported to platforms such as Nintendo Switch, PlayStation Vita, 
-            and Wii U.<a href="#footnote145"><sup>[145]</sup></a><a href="#footnote146"><sup>[146]</sup></a> Take-Two issued a DMCA takedown for the project in 
-            February 2021.<a href="#footnote147"><sup>[147]</sup></a> In April, Theo, a New Zealand-based developer who maintained a fork of the source code, 
-            filed a counter-notice on GitHub, claiming that the code does not contain any original work owned by Take-Two; per DMCA rules regarding disputes, 
-            Theo's content was restored after two weeks.<a href="#footnote148"><sup>[148]</sup></a> On 10 June 2021, the team behind <em>reVC</em> filed a 
-            counter-notice; per DMCA rules regarding disputes, the source code was restored after two weeks.<a href="#footnote149"><sup>[149]</sup></a> 
-            In September 2021, Take-Two filed a lawsuit in California against the programmers, asserting that the projects constitute 
-            copyright infringement.<a href="#footnote150"><sup>[150]</sup></a>
-        </p>
+                <p>
+                    For its tenth anniversary in 2012, <em>Vice City</em> was ported to mobile devices by War Drum
+                    Studios, building on the Windows version with
+                    enhanced visuals and a customisable layout.<a href="#footnote64"><sup>[64]</sup></a> It was released
+                    for iOS devices on 6
+                    December,<a href="#footnote137"><sup>[137]</sup></a>
+                    for Android on 12 December following a delay due to technical issues,<a
+                        href="#footnote138"><sup>[138]</sup></a> and for Fire OS on
+                    15 May 2014.<a href="#footnote139"><sup>[139]</sup></a> An emulated version of <em>Vice City</em>
+                    was released on the PlayStation 3
+                    on 30 January 2013 via the PlayStation Network's PS2 Classics;<a
+                        href="#footnote135"><sup>[140]</sup></a> another emulated version was
+                    released for the PlayStation 4 on 5 December 2015, upscaled to 1080p and with support for
+                    Trophies.<a href="#footnote141"><sup>[141]</sup></a> A
+                    remastered version of The Trilogy, subtitled <a
+                        href=”https://en.wikipedia.org/wiki/Grand_Theft_Auto:_The_Trilogy_%E2%80%93_The_Definitive_Edition”
+                        title=”The Definitive Edition”><em>The Definitive Edition</em></a>,
+                    was released for the Nintendo Switch, PlayStation 4,
+                    PlayStation 5, Windows, Xbox One, and Xbox Series X/S on 11 November 2021,<a
+                        href="#footnote142"><sup>[142]</sup></a> and for Android and iOS on
+                    14 December 2023.<a href="#footnote143"><sup>[143]</sup></a> The original game was removed
+                    from digital retailers in preparation for <em>The Definitive Edition</em>,<a
+                        href="#footnote142"><sup>[142]</sup></a>
+                    but later restored as a bundle on the Rockstar Store.<a href="#footnote144"><sup>[144]</sup></a>
+                </p>
 
-        <p>
-            A team of Russian modders released an unofficial port of the game to <em>Grand Theft Auto IV</em>'s engine in January 2025, aiming to address perceived issues 
-            with <em>The Definitive Edition</em>.<a href="#footnote151"><sup>[151]</sup></a><a href="#footnote152"><sup>[152]</sup></a> A DMCA complaint by Take-Two resulted in the 
-            eletion of the mod's trailer and YouTube channel, though some journalists noted the 2022 decree protecting Russian companies from 
-            copyright enforcement by Western firms (as a result of the Russian invasion of Ukraine) may shield the mod and team from legal action by 
-            Take-Two.<a href="#footnote153"><sup>[153]</sup></a><a href="#footnote154"><sup>[154]</sup></a> <em>Vice City</em>'s technical director, Obbe Vermeij, defended Take-Two's 
-            decision, opining that the mod "directly competes" with <em>The Definitive Edition</em>, though he acknowledged the takedown "would be easier to swallow if 
-            [Rockstar] produced competent re-masters".<a href="#footnote155"><sup>[155]</sup></a>
-        </p>
-    
+                <p>
+                    A core team of six fans reverse-engineered the game and released it as an executable in December
+                    2020, having worked on it since May;
+                    titled <em>reVC</em>, the project allows the game to be unofficially ported to platforms such as
+                    Nintendo Switch, PlayStation Vita,
+                    and Wii U.<a href="#footnote145"><sup>[145]</sup></a><a href="#footnote146"><sup>[146]</sup></a>
+                    Take-Two issued a DMCA takedown for the project in
+                    February 2021.<a href="#footnote147"><sup>[147]</sup></a> In April, Theo, a New Zealand-based
+                    developer who maintained a fork of the source code,
+                    filed a counter-notice on GitHub, claiming that the code does not contain any original work owned by
+                    Take-Two; per DMCA rules regarding disputes,
+                    Theo's content was restored after two weeks.<a href="#footnote148"><sup>[148]</sup></a> On 10 June
+                    2021, the team behind <em>reVC</em> filed a
+                    counter-notice; per DMCA rules regarding disputes, the source code was restored after two weeks.<a
+                        href="#footnote149"><sup>[149]</sup></a>
+                    In September 2021, Take-Two filed a lawsuit in California against the programmers, asserting that
+                    the projects constitute
+                    copyright infringement.<a href="#footnote150"><sup>[150]</sup></a>
+                </p>
+
+                <p>
+                    A team of Russian modders released an unofficial port of the game to <em>Grand Theft Auto IV</em>'s
+                    engine in January 2025, aiming to address perceived issues
+                    with <em>The Definitive Edition</em>.<a href="#footnote151"><sup>[151]</sup></a><a
+                        href="#footnote152"><sup>[152]</sup></a> A DMCA complaint by Take-Two resulted in the
+                    eletion of the mod's trailer and YouTube channel, though some journalists noted the 2022 decree
+                    protecting Russian companies from
+                    copyright enforcement by Western firms (as a result of the Russian invasion of Ukraine) may shield
+                    the mod and team from legal action by
+                    Take-Two.<a href="#footnote153"><sup>[153]</sup></a><a href="#footnote154"><sup>[154]</sup></a>
+                    <em>Vice City</em>'s technical director, Obbe Vermeij, defended Take-Two's
+                    decision, opining that the mod "directly competes" with <em>The Definitive Edition</em>, though he
+                    acknowledged the takedown "would be easier to swallow if
+                    [Rockstar] produced competent re-masters".<a href="#footnote155"><sup>[155]</sup></a>
+                </p>
+
     </main>
     </section>
 
-        <!-- Border overlay element -->
-        <div class="border-overlay"></div>
-    
-        <footer> 
-            <h2>References</h2>
-            <ul>
-                <li 
-                    id="footnote122">
-                    <strong>[122]</strong> Snider, Mike (27 December 2002). 
-                    "<a href="https://www.usatoday.com/story/entertainment/2002/12/27/gta-legacy/">The legacy of 'Grand Theft Auto'</a>". 
-                    USA Today. Gannett Company. Archived from the original on 29 September 2018. Retrieved 9 October 2016. 
-                    <a href="#footnote-return-122"></a>
-                </li>
+    <!-- Border overlay element -->
+    <div class="border-overlay"></div>
 
-                <li id="footnote123">
-                    <strong>[123]</strong> Plunkett, Luke (3 December 2012). 
-                    "<a href="https://kotaku.com/lets-rank-the-grand-theft-auto-games-best-to-worst-5966355">Let's Rank The Grand Theft Auto Games, Best to 'Worst'</a>". 
-                    Kotaku. Gawker Media. Archived from the original on 8 October 2016. Retrieved 9 October 2016. 
-                    <a href="#footnote-return-123"></a>
-                </li>
+    <footer>
+        <h2>References</h2>
+        <ul>
+            <li id="footnote31"><strong>[31]</strong> Norris, Erik (6 December 2012). <a
+                    href="https://web.archive.org/web/20161220150207/http://www.craveonline.com/site/201175-missing-you-looking-back-at-gta-vice-city-w-rockstar-games">"Missing
+                    You: Looking Back at GTA: Vice City w/ Rockstar Games"</a>. CraveOnline. Atomic Media.</li>
+            <li id="footnote64"><strong>[64]</strong> R* Q (26 October 2012). <a
+                    href="https://web.archive.org/web/20160411151522/http://www.rockstargames.com/newswire/article/45851/celebrating-the-grand-theft-auto-vice-city-10th-anniversary-plus.html"">"
+                    Celebrating the Grand Theft Auto: Vice City 10th Anniversary plus Details on the Upcoming Mobile
+                    Release"</a>. Rockstar Newswire. Rockstar Games.</li>
+            <li id="footnote122"><strong>[122]</strong> Snider, Mike (27 December 2002). <a
+                    href="http://usatoday30.usatoday.com/tech/techreviews/games/2002-12-27-gta-best_x.htm">"The legacy
+                    of 'Grand Theft Auto'"</a>. USA Today. Gannett Company.</li>
+            <li id="footnote123"><strong>[123]</strong> Plunkett, Luke (3 December 2012). <a
+                    href="https://kotaku.com/5965358/lets-rank-the-grand-theft-auto-games-best-to-worst/">"Let's Rank
+                    The Grand Theft Auto Games, Best to "</a>Worst"". Kotaku. Gawker Media.</li>
+            <li id="footnote124"><strong>[124]</strong> Wilson, Jeffrey L. (17 September 2013). <a
+                    href="https://web.archive.org/web/20130922043626/http://www.pcmag.com/slideshow/story/315920/the-5-best-grand-theft-auto-games/5">"The
+                    5 Best Grand Theft Auto Games"</a>. PC Magazine. Ziff Davis.</li>
+            <li id="footnote125"><strong>[125]</strong> <a
+                    href="https://www.theguardian.com/technology/gamesblog/2010/oct/01/games-sony">"Official PlayStation
+                    readers name 50 best PlayStation games ever"</a>. The Guardian. 1 October 2010.</li>
+            <li id="footnote126"><strong>[126]</strong> <a
+                    href="https://web.archive.org/web/20090731213541/http://www.next-gen.biz/features/japan-votes-all-time-top-100?page=0%2C1">"Japan
+                    Votes on All Time Top 100"</a>. Edge. Future plc. 3 March 2006.</li>
+            <li id="footnote127"><strong>[127]</strong> Parrish, Ash (5 December 2023). <a
+                    href="https://www.theverge.com/2023/12/4/23988446/gta-vi-trailer-leaked-vice-city">"The first GTA VI
+                    trailer is here"</a>. The Verge. Vox Media.</li>
+            <li id="footnote128"><strong>[128]</strong> <a
+                    href="https://web.archive.org/web/20220523081848/https://ir.take2games.com/news-releases/news-release-details/rockstar-games-ships-grand-theft-auto-vice-city-pc">"Rockstar
+                    Games Ships Grand Theft Auto: Vice City PC"</a> (Press release). Take-Two Interactive. 12 May 2003.
+            </li>
+            <li id="footnote129"><strong>[129]</strong> Parker, Sam (14 February 2003). <a
+                    href="http://www.gamespot.com/articles/vice-city-pc-release-date-revealed/1100-2911002/">"Vice City
+                    PC release date revealed"</a>. GameSpot. CBS Interactive.</li>
+            <li id="footnote130"><strong>[130]</strong> <a
+                    href="https://web.archive.org/web/20220523085142/https://ir.take2games.com/news-releases/news-release-details/rockstar-games-ships-grand-theft-auto-double-pack-xbox">"Rockstar
+                    Games Ships Grand Theft Auto Double Pack for Xbox"</a> (Press release). Take-Two Interactive. 4
+                November 2003.</li>
+            <li id="footnote131"><strong>[131]</strong> <a
+                    href="https://web.archive.org/web/20060323042150/http://www.take2games.com/index.php?p=pr&release=European%20Ship%20Date%20Announced&page=1">"Rockstar
+                    Games Announces European Ship Date for Grand Theft Auto Double Pack for Xbox"</a> (Press release).
+                Take-Two Interactive. 8 December 2003.</li>
+            <li id="footnote132"><strong>[132]</strong> Boulding, Aaron (4 November 2003). <a
+                    href="https://ign.com/articles/2003/11/05/grand-theft-auto-double-pack">"Grand Theft Auto Double
+                    Pack"</a>. IGN. Ziff Davis.</li>
+            <li id="footnote133"><strong>[133]</strong> Surette, Tim (23 October 2005). <a
+                    href="http://www.gamespot.com/articles/gta-gets-trilogized-san-andreas-special-edition/1100-6134252/">"GTA
+                    gets trilogized, San Andreas special edition"</a>. GameSpot. CBS Interactive.</li>
+            <li id="footnote134"><strong>[134]</strong> Seitz, Patrick (25 April 2003). <a
+                    href="https://web.archive.org/web/20030425114929/http://www.investors.com:80/editorial/tech.asp?v=4/12">"Edgy
+                    Games Drive Adults To Play More"</a>. Investor's Business Daily.</li>
+            <li id="footnote135"><strong>[135]</strong> Zwiezen, Zack (24 October 2021). <a
+                    href="https://kotaku.com/gta-has-a-weird-history-on-nintendo-consoles-1847923897">"GTA Has A Weird
+                    History On Nintendo Consoles"</a>. Kotaku. G/O Media.</li>
+            <li id="footnote136"><strong>[136]</strong> R* Q (12 November 2010). <a
+                    href="http://www.rockstargames.com/newswire/article/11761/grand-theft-auto-trilogy-now-available-for-the-mac.html">"Grand
+                    Theft Auto Trilogy Now Available for the Mac"</a>. Rockstar Newswire. Rockstar Games.</li>
+            <li id="footnote137"><strong>[137]</strong> Ivan, Tom (6 December 2012). <a
+                    href="https://web.archive.org/web/20121208053546/http://www.computerandvideogames.com/382378/gta-vice-city-hits-ios-android-version-held-up/">"GTA:
+                    Vice City hits iOS, Android version held up"</a>. Computer and Video Games. Future plc.</li>
+            <li id="footnote138"><strong>[138]</strong> Ivan, Tom (13 December 2012). <a
+                    href="https://web.archive.org/web/20121217224250/http://www.computerandvideogames.com/383547/gta-vice-city-hits-android-following-delay/">"GTA:
+                    Vice City hits Android following delay"</a>. Computer and Video Games. Future plc.</li>
+            <li id="footnote139"><strong>[139]</strong> Farokhmanesh, Megan (15 May 2014). <a
+                    href="https://www.polygon.com/2014/5/15/5721390/grand-theft-auto-trilogy-amazon-fire-tv-kindle-fire">"Grand
+                    Theft Auto trilogy launches for Amazon Fire TV, Kindle Fire"</a>. Polygon.</li>
+            <li id="footnote140"><strong>[140]</strong> R* Q (30 January 2013). <a
+                    href="http://www.rockstargames.com/newswire/article/48571/vice-city-now-available-on-psn.html">"Vice
+                    City Now Available on PSN"</a>. Rockstar Newswire. Rockstar Games.</li>
+            <li id="footnote141"><strong>[141]</strong> Yoshida, Shuhei (4 December 2015). <a
+                    href="http://blog.us.playstation.com/2015/12/04/fan-favorite-ps2-games-launching-on-ps4-tomorrow/">"Fan-Favorite
+                    PS2 Games Launching on PS4 Tomorrow"</a>. PlayStation Blog. Sony Computer Entertainment.</li>
+            <li id="footnote142"><strong>[142]</strong> Skrebels, Joe (22 October 2021). <a
+                    href="https://www.ign.com/articles/grand-theft-auto-gta-trilogy-trailer-gameplay-price-release-date-the-definitive-edition">"Grand
+                    Theft Auto: The Trilogy – The Definitive Edition Gets Gameplay Trailer, November Release Date"</a>.
+                IGN. Ziff Davis.</li>
+            <li id="footnote143"><strong>[143]</strong> Patches, Matt (29 November 2023). <a
+                    href="https://www.polygon.com/23980880/netflix-play-grand-theft-auto-3-vice-city-trilogy-app-release">"Netflix
+                    has landed The Grand Theft Auto Trilogy"</a>. Polygon. Vox Media.</li>
+            <li id="footnote144"><strong>[144]</strong> Valentine, Rebekah (19 November 2021). <a
+                    href="https://www.ign.com/articles/original-versions-gta-trilogy-relisted-pc">"Original Versions of
+                    the GTA Trilogy to Be Relisted for Sale on PC"</a>. IGN. Ziff Davis.</li>
+            <li id="footnote145"><strong>[145]</strong> Yin-Poole, Wesley (17 February 2021). <a
+                    href="https://www.eurogamer.net/articles/2021-02-17-how-a-small-group-of-gta-fanatics-reverse-engineered-gta-3-and-vice-city-without-so-far-getting-shut-down-by-take-two">"How
+                    a small group of GTA fanatics reverse-engineered GTA 3 and Vice City without (so far) getting shut
+                    down"</a>. Eurogamer. Gamer Network.</li>
+            <li id="footnote146"><strong>[146]</strong> Wright, Steven T. (15 February 2021). <a
+                    href="https://www.gamespot.com/articles/gta-3-and-vice-city-have-been-reverse-engineered-on-pc/1100-6487561/">"GTA
+                    3 And Vice City Have Been Reverse-Engineered On PC"</a>. GameSpot. Red Ventures.</li>
+            <li id="footnote147"><strong>[147]</strong> Yin-Poole, Wesley (20 February 2021). <a
+                    href="https://www.eurogamer.net/articles/2021-02-20-gta-3-and-vice-city-reverse-engineering-fan-project-hit-with-dmca-takedown">"GTA
+                    3 and Vice City reverse-engineering fan project hit with DMCA takedown"</a>. Eurogamer. Gamer
+                Network.</li>
+            <li id="footnote148"><strong>[148]</strong> Zwiezen, Zack (10 May 2021). <a
+                    href="https://kotaku.com/lone-developer-stands-up-to-grand-theft-auto-dmca-claim-1846864410">"Lone
+                    Developer Stands Up To Grand Theft Auto DMCA Claims, Wins"</a>. Kotaku. G/O Media.</li>
+            <li id="footnote149"><strong>[149]</strong> Yin-Poole, Wesley (28 June 2021). <a
+                    href="https://www.eurogamer.net/articles/2021-06-28-gta-3-and-vice-city-reverse-engineering-fan-project-back-online-after-take-two-takedown">"GTA
+                    3 and Vice City reverse-engineering fan project back online after Take-Two takedown"</a>. Eurogamer.
+                Gamer Network.</li>
+            <li id="footnote150"><strong>[150]</strong> Scullion, Chris (3 September 2021). <a
+                    href="https://www.videogameschronicle.com/news/take-two-is-suing-the-creators-of-a-gta-3-and-vice-city-reverse-engineering-projects/">"Take-Two
+                    is suing the creators of GTA 3 and Vice City reverse engineering projects"</a>. Video Games
+                Chronicle. Gamer Network.</li>
+            <li id="footnote151"><strong>[151]</strong> McFerran (21 January 2025). <a
+                    href="https://www.timeextension.com/news/2025/01/gta-vice-city-nextgen-edition-is-the-closest-thing-well-get-to-a-proper-remaster">"GTA
+                    Vice City: Nextgen Edition Is 'The Closest Thing We'll Get' To A Proper Remaster"</a>. Time
+                Extension. Gamer Network.</li>
+            <li id="footnote152"><strong>[152]</strong> Troughton, James (21 January 2025). <a
+                    href="https://www.thegamer.com/grand-theft-auto-vice-city-fan-made-remaster-gta-4-engine/">"Fans Are
+                    Remastering Vice City In GTA 4"</a>. TheGamer. Valnet.</li>
+            <li id="footnote153"><strong>[153]</strong> Van der Velde, Issy (22 January 2025). <a
+                    href="https://www.gamesradar.com/games/grand-theft-auto/rockstar-literally-just-took-down-a-liberty-city-gta-5-mod-but-thats-not-stopping-these-modders-porting-vice-city-into-gta-4-and-they-might-just-get-away-with-it/">"Rockstar
+                    literally just took down a Liberty City GTA 5 mod, but that's not stopping these modders porting
+                    Vice City into GTA 4 - and they might just get away with it"</a>. GamesRadar+. Future plc.</li>
+            <li id="footnote154"><strong>[154]</strong> Bardhan, Ashley (23 January 2025). <a
+                    href="https://www.gamesradar.com/games/action/gta-4-modders-lose-their-youtube-channel-as-take-two-seems-to-continue-its-quest-to-obliterate-every-gta-mod-but-they-still-plan-to-deliver-their-upgraded-vice-city/">"GTA
+                    4 modders lose their YouTube channel as Take-Two seems to continue its quest to obliterate every GTA
+                    mod, but they still plan to deliver their upgraded Vice City"</a>. GamesRadar+. Future plc.</li>
+            <li id="footnote155"><strong>[155]</strong> Van der Velde, Issy (27 January 2025). <a
+                    href="https://www.gamesradar.com/games/grand-theft-auto/former-gta-dev-weighs-in-on-rockstars-attempt-to-silence-vice-city-mod-that-ports-the-whole-game-to-gta-4-this-is-what-companies-are-supposed-to-do/">"Former
+                    GTA dev weighs in on Rockstar's attempt to silence Vice City mod that ports the whole game to GTA 4:
+                    'This is what companies are supposed to do'"</a>. GamesRadar+. Future plc.</li>
 
-                <li id="footnote124">
-                    <strong>[124]</strong> Wilson, Jeffrey L. (17 September 2013). 
-                    "<a href="https://www.pcmag.com/article2/0,2817,2424573,00.asp">The 5 Best Grand Theft Auto Games</a>". 
-                    PC Magazine. Ziff Davis. Archived from the original on 22 September 2013. Retrieved 9 October 2016. 
-                    <a href="#footnote-return-124"></a>
-                </li>
 
-                <li id="footnote125">
-                    <strong>[125]</strong> "Official PlayStation readers name 50 best PlayStation games ever". The Guardian. 1 October 2010. 
-                    Archived from the original on 29 April 2016. Retrieved 17 April 2016. 
-                    <a href="#footnote-return-125"></a>
-                </li>
+        </ul>
+    </footer>
 
-                <li id="footnote126">
-                    <strong>[126]</strong> "Japan Votes on All Time Top 100". Edge. Future plc. 3 March 2006. 
-                    Archived from the original on 31 July 2009. Retrieved 17 April 2016. 
-                    <a href="#footnote-return-126"></a>
-                </li>
-
-                <li id="footnote127">
-                    <strong>[127]</strong> Parrish, Ash (5 December 2023). 
-                    "<a href="https://www.theverge.com/2023/12/5/23989687/gta-vi-trailer-release-date">The first GTA VI trailer is here</a>". 
-                    The Verge. Vox Media. Archived from the original on 4 December 2023. Retrieved 5 December 2023. 
-                    <a href="#footnote-return-127"></a>
-                </li>
-
-                <li id="footnote128">
-                    <strong>[128]</strong> "Rockstar Games Ships Grand Theft Auto: Vice City PC" (Press release). Take-Two Interactive. 12 May 2003. 
-                    Archived from the original on 23 May 2022. Grand Theft Auto: Vice City is set to be in stores May 13th in North America and May 16th in Europe. 
-                    <a href="#footnote-return-128"></a>
-                </li>
-
-                <li id="footnote129">
-                    <strong>[129]</strong> Parker, Sam (14 February 2003). 
-                    "<a href="https://www.gamespot.com/articles/vice-city-pc-release-date-revealed/1100-2908471/">Vice City PC release date revealed</a>". 
-                    GameSpot. CBS Interactive. Archived from the original on 7 November 2018. Retrieved 23 September 2016. 
-                    <a href="#footnote-return-129"></a>
-                </li>
-
-                <li id="footnote130">
-                    <strong>[130]</strong> "Rockstar Games Ships Grand Theft Auto Double Pack for Xbox" (Press release). Take-Two Interactive. 4 November 2003. 
-                    Archived from the original on 23 May 2022. 
-                    <a href="#footnote-return-130"></a>
-                </li>
-
-                <li id="footnote131">
-                    <strong>[131]</strong> Take-Two Interactive (8 December 2003). 
-                    "<a href="#">Rockstar Games Announces European Ship Date for Grand Theft Auto Double Pack for Xbox</a>". 
-                    Press release. Archived from the original on 23 March 2006. 
-                    <a href="#footnote-return-131"></a>
-                </li>
-
-                <li id="footnote132">
-                    <strong>[132]</strong> Boulding, Aaron (4 November 2003). 
-                    "<a href="#">Grand Theft Auto Double Pack</a>". 
-                    IGN. Ziff Davis. Archived from the original on 24 December 2015. Retrieved 25 September 2014. 
-                    <a href="#footnote-return-132"></a>
-                </li>
-
-                <li id="footnote133">
-                    <strong>[133]</strong> Surette, Tim (23 October 2005). 
-                    "<a href="#">GTA gets trilogized, San Andreas special edition</a>". 
-                    GameSpot. CBS Interactive. Archived from the original on 6 January 2016. Retrieved 17 April 2016. 
-                    <a href="#footnote-return-133"></a>
-                </li>
-
-                <li id="footnote134">
-                    <strong>[134]</strong> Seitz, Patrick (25 April 2003). 
-                    "<a href="#">Edgy Games Drive Adults To Play More</a>". 
-                    Investor's Business Daily. Archived from the original on 25 April 2003. Retrieved 7 November 2023. 
-                    <a href="#footnote-return-134"></a>
-                </li>
-
-                <li id="footnote135">
-                    <strong>[135]</strong> Zwiezen, Zack (24 October 2021). 
-                    "<a href="#">GTA Has A Weird History On Nintendo Consoles</a>". 
-                    Kotaku. G/O Media. Archived from the original on 24 October 2021. Retrieved 7 November 2023. 
-                    <a href="#footnote-return-135"></a>
-                </li>
-
-                <li id="footnote136">
-                    <strong>[136]</strong> R* Q (12 November 2010). 
-                    "<a href="#">Grand Theft Auto Trilogy Now Available for the Mac</a>". 
-                    Rockstar Newswire. Rockstar Games. Archived from the original on 18 October 2015. Retrieved 25 September 2014. 
-                    <a href="#footnote-return-136"></a>
-                </li>
-
-                <li id="footnote137">
-                    <strong>[137]</strong> Ivan, Tom (6 December 2012). 
-                    "<a href="#">GTA: Vice City hits iOS, Android version held up</a>". 
-                    Computer and Video Games. Future plc. Archived from the original on 8 December 2012. Retrieved 16 April 2016. 
-                    <a href="#footnote-return-137"></a>
-                </li>
-
-                <li id="footnote138">
-                    <strong>[138]</strong> Ivan, Tom (13 December 2012). 
-                    "<a href="#">GTA: Vice City hits Android following delay</a>". 
-                    Computer and Video Games. Future plc. Archived from the original on 17 December 2012. Retrieved 18 February 2021. 
-                    <a href="#footnote-return-138"></a>
-                </li>
-                
-                <li id="footnote139">
-                    <strong>[139]</strong> Farokhmanesh, Megan (15 May 2014). 
-                    "<a href="#">Grand Theft Auto trilogy launches for Amazon Fire TV, Kindle Fire</a>". 
-                    Polygon. Archived from the original on 28 August 2019. Retrieved 17 December 2019. 
-                    <a href="#footnote-return-139"></a>
-                </li>
-
-                <li id="footnote140">
-                    <strong>[140]</strong> R* Q (30 January 2013). 
-                    "<a href="#">Vice City Now Available on PSN</a>". 
-                    Rockstar Newswire. Rockstar Games. Archived from the original on 12 March 2016. Retrieved 17 April 2016. 
-                    <a href="#footnote-return-140"></a>
-                </li>
-
-                <li id="footnote141">
-                    <strong>[141]</strong> Yoshida, Shuhei (4 December 2015). 
-                    "<a href="#">Fan-Favorite PS2 Games Launching on PS4 Tomorrow</a>". 
-                    PlayStation Blog. Sony Computer Entertainment. Archived from the original on 12 December 2015. Retrieved 21 December 2015. 
-                    <a href="#footnote-return-141"></a>
-                </li>
-                
-                <li id="footnote142">
-                    <strong>[142]</strong> Skrebels, Joe (22 October 2021). 
-                    "<a href="#">Grand Theft Auto: The Trilogy – The Definitive Edition Gets Gameplay Trailer, November Release Date</a>". 
-                    IGN. Ziff Davis. Archived from the original on 22 October 2021. Retrieved 22 October 2021. 
-                    <a href="#footnote-return-142"></a>
-                </li>
-                
-        
-                    <!-- Add more references, but I want to add something to the CSS -->
-        
-            </ul>
-        </footer>
-
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
-    <!-- Footer section for my individual page. Here, I've added some italics where needed. -->
+<!-- Footer section for my individual page. Here, I've added some italics where needed. -->
+
 </html>


### PR DESCRIPTION
The Home and About pages do not have any in-text references, so this should mean the references are complete.

NOTE1: It looks like the affected pages may have had existing issues with their formatting of the references section. This isn't within the scope of this pull request, but needs to be resolved urgently.

NOTE2: Vscode's automatic formatting has moved a bunch of stuff around. It should not affect the functioning of the HTML but it should be a lot more readable.