### PR TITLE
Added a scroll offset to footer entries

### DIFF
--- a/Test/styles.css
+++ b/Test/styles.css
@@ -169,3 +169,9 @@ img.float-right {
     margin-left: 50px;
     max-width: 100%;
 }
+
+/* Scroll offset for footer links.
+This ensures the in-text links to references will have an appropriate offset to account for the unusual shape of our page. */
+footer li {
+    scroll-margin-top : 140px;
+}


### PR DESCRIPTION
This ensures that after clicking an in-text link, the target entry will be visible at the top of the page instead of obscured by the special cutout.